### PR TITLE
HYDRAN-2366: surface organizationName in history RecipientDetails

### DIFF
--- a/src/main/java/se/sundsvall/postportalservice/integration/messaging/MessagingMapper.java
+++ b/src/main/java/se/sundsvall/postportalservice/integration/messaging/MessagingMapper.java
@@ -35,6 +35,7 @@ import static org.apache.commons.lang3.ObjectUtils.anyNull;
 import static org.springframework.http.HttpStatus.BAD_GATEWAY;
 import static se.sundsvall.postportalservice.service.util.MessagingSettingsUtil.SNAILMAIL_CALLBACK_EMAIL;
 import static se.sundsvall.postportalservice.service.util.MessagingSettingsUtil.SNAILMAIL_CALLBACK_SUBJECT;
+import static se.sundsvall.postportalservice.service.util.StringUtil.calculateRecipientName;
 
 public final class MessagingMapper {
 
@@ -49,19 +50,7 @@ public final class MessagingMapper {
 		""";
 
 	static String formatRecipientName(final RecipientEntity recipientEntity) {
-		final var firstName = recipientEntity.getFirstName();
-		final var lastName = recipientEntity.getLastName();
-		final var organizationName = recipientEntity.getOrganizationName();
-		final var hasPersonName = firstName != null && !firstName.isBlank() && lastName != null && !lastName.isBlank();
-		final var hasOrganizationName = organizationName != null && !organizationName.isBlank();
-
-		if (hasOrganizationName && hasPersonName) {
-			return "%s (att: %s %s)".formatted(organizationName, firstName, lastName);
-		}
-		if (hasOrganizationName) {
-			return organizationName;
-		}
-		return "%s %s".formatted(firstName, lastName);
+		return calculateRecipientName(recipientEntity.getFirstName(), recipientEntity.getLastName(), recipientEntity.getOrganizationName());
 	}
 
 	private static final String EMAIL_SENDER_NAME = "Postportalen";

--- a/src/main/java/se/sundsvall/postportalservice/service/mapper/HistoryMapper.java
+++ b/src/main/java/se/sundsvall/postportalservice/service/mapper/HistoryMapper.java
@@ -15,7 +15,7 @@ import se.sundsvall.postportalservice.integration.db.converter.MessageType;
 
 import static java.util.Collections.emptyList;
 import static java.util.Optional.ofNullable;
-import static se.sundsvall.postportalservice.service.util.StringUtil.calculateFullName;
+import static se.sundsvall.postportalservice.service.util.StringUtil.calculateRecipientName;
 
 @Component
 public class HistoryMapper {
@@ -79,7 +79,7 @@ public class HistoryMapper {
 				.withCity(recipientEntity.getCity())
 				.withStreetAddress(recipientEntity.getStreetAddress())
 				.withMobileNumber(recipientEntity.getPhoneNumber())
-				.withName(calculateFullName(recipientEntity.getFirstName(), recipientEntity.getLastName()))
+				.withName(calculateRecipientName(recipientEntity.getFirstName(), recipientEntity.getLastName(), recipientEntity.getOrganizationName()))
 				.withMessageType(ofNullable(recipientEntity.getMessageType()).map(MessageType::name).orElse(null))
 				.withStatus(recipientEntity.getStatus())
 				.withZipCode(recipientEntity.getZipCode()))

--- a/src/main/java/se/sundsvall/postportalservice/service/util/StringUtil.java
+++ b/src/main/java/se/sundsvall/postportalservice/service/util/StringUtil.java
@@ -15,4 +15,28 @@ public final class StringUtil {
 			ofNullable(firstName).map(String::trim).orElse(""),
 			ofNullable(lastName).map(String::trim).orElse("")).trim();
 	}
+
+	/**
+	 * Build a recipient display name from a combination of person name and organisation name.
+	 *
+	 * <ul>
+	 * <li>Both organisation name and person name present → {@code "<organisation> (att: <firstName> <lastName>)"}</li>
+	 * <li>Only organisation name present → {@code "<organisation>"}</li>
+	 * <li>Only person name present → {@code "<firstName> <lastName>"} (via {@link #calculateFullName})</li>
+	 * <li>Nothing present → {@code null}</li>
+	 * </ul>
+	 */
+	public static String calculateRecipientName(final String firstName, final String lastName, final String organizationName) {
+		final var personName = calculateFullName(firstName, lastName);
+		final var hasOrganizationName = organizationName != null && !organizationName.isBlank();
+		final var hasPersonName = personName != null && !personName.isBlank();
+
+		if (hasOrganizationName && hasPersonName) {
+			return "%s (att: %s)".formatted(organizationName, personName);
+		}
+		if (hasOrganizationName) {
+			return organizationName;
+		}
+		return personName;
+	}
 }

--- a/src/test/java/se/sundsvall/postportalservice/TestDataFactory.java
+++ b/src/test/java/se/sundsvall/postportalservice/TestDataFactory.java
@@ -107,7 +107,9 @@ public final class TestDataFactory {
 	 * @return          a 12-digit legal ID string
 	 */
 	public static String generateLegalId(final int yearsOld, final String suffix) {
-		final var birthDate = LocalDate.now().minusYears(yearsOld);
+		// LegalIdUtil.isAnAdult uses LocalDate.now() to compute age; this generator must use the same "today" so the
+		// resulting ID lands on the expected side of the 18-year boundary in age-categorisation tests.
+		final var birthDate = LocalDate.now().minusYears(yearsOld); // NOSONAR
 		final var dateFormatter = DateTimeFormatter.ofPattern("yyyyMMdd");
 		return birthDate.format(dateFormatter) + suffix;
 	}

--- a/src/test/java/se/sundsvall/postportalservice/api/HistoryResourceTest.java
+++ b/src/test/java/se/sundsvall/postportalservice/api/HistoryResourceTest.java
@@ -196,7 +196,7 @@ class HistoryResourceTest {
 		final var orderReference = "orderReference";
 		final var signature = "signature";
 		final var oscpResponse = "ocspResponse";
-		final var signedAt = OffsetDateTime.now();
+		final var signedAt = OffsetDateTime.of(2024, 6, 15, 12, 0, 0, 0, java.time.ZoneOffset.UTC);
 		final var result = SigningInformation.create()
 			.withStatus(status)
 			.withContentKey(contentKey)

--- a/src/test/java/se/sundsvall/postportalservice/api/HistoryResourceTest.java
+++ b/src/test/java/se/sundsvall/postportalservice/api/HistoryResourceTest.java
@@ -23,6 +23,7 @@ import se.sundsvall.postportalservice.api.model.SigningInformation;
 import se.sundsvall.postportalservice.api.model.SigningStatus;
 import se.sundsvall.postportalservice.service.HistoryService;
 
+import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -196,7 +197,7 @@ class HistoryResourceTest {
 		final var orderReference = "orderReference";
 		final var signature = "signature";
 		final var oscpResponse = "ocspResponse";
-		final var signedAt = OffsetDateTime.of(2024, 6, 15, 12, 0, 0, 0, java.time.ZoneOffset.UTC);
+		final var signedAt = OffsetDateTime.of(2024, 6, 15, 12, 0, 0, 0, UTC);
 		final var result = SigningInformation.create()
 			.withStatus(status)
 			.withContentKey(contentKey)

--- a/src/test/java/se/sundsvall/postportalservice/api/model/MessageDetailsTest.java
+++ b/src/test/java/se/sundsvall/postportalservice/api/model/MessageDetailsTest.java
@@ -2,7 +2,7 @@ package se.sundsvall.postportalservice.api.model;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -12,7 +12,6 @@ import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanHashCode;
 import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanToString;
 import static com.google.code.beanmatchers.BeanMatchers.hasValidGettersAndSetters;
 import static com.google.code.beanmatchers.BeanMatchers.registerValueGenerator;
-import static java.time.LocalDateTime.now;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.allOf;
 
@@ -21,7 +20,8 @@ class MessageDetailsTest {
 	// MessageDetails attributes
 	private static final String SUBJECT = "subject";
 	private static final String BODY = "body";
-	private static final LocalDateTime SENT_AT = now();
+	private static final LocalDateTime SENT_AT = LocalDateTime.of(2024, 6, 15, 12, 0, 0);
+	private static final AtomicInteger SEQUENCE = new AtomicInteger();
 	private static final SigningStatus SIGNING_STATUS = new SigningStatus();
 	private static final List<MessageDetails.AttachmentDetails> ATTACHMENTS = List.of(new MessageDetails.AttachmentDetails());
 	private static final List<MessageDetails.RecipientDetails> RECIPIENTS = List.of(new MessageDetails.RecipientDetails());
@@ -43,7 +43,7 @@ class MessageDetailsTest {
 
 	@BeforeAll
 	static void setup() {
-		registerValueGenerator(() -> now().plusDays(new Random().nextInt()), LocalDateTime.class);
+		registerValueGenerator(() -> SENT_AT.plusDays(SEQUENCE.incrementAndGet()), LocalDateTime.class);
 	}
 
 	@Test

--- a/src/test/java/se/sundsvall/postportalservice/api/model/MessageTest.java
+++ b/src/test/java/se/sundsvall/postportalservice/api/model/MessageTest.java
@@ -1,7 +1,7 @@
 package se.sundsvall.postportalservice.api.model;
 
 import java.time.LocalDateTime;
-import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -11,7 +11,6 @@ import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanHashCode;
 import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanToString;
 import static com.google.code.beanmatchers.BeanMatchers.hasValidGettersAndSetters;
 import static com.google.code.beanmatchers.BeanMatchers.registerValueGenerator;
-import static java.time.LocalDateTime.now;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.allOf;
 
@@ -23,10 +22,11 @@ class MessageTest {
 	private static final String TYPE = "type";
 	private static final LocalDateTime SENT_AT = LocalDateTime.of(2021, 1, 1, 12, 0, 0);
 	private static final SigningStatus SIGNING_STATUS = SigningStatus.create();
+	private static final AtomicInteger SEQUENCE = new AtomicInteger();
 
 	@BeforeAll
 	static void setup() {
-		registerValueGenerator(() -> now().plusDays(new Random().nextInt()), LocalDateTime.class);
+		registerValueGenerator(() -> SENT_AT.plusDays(SEQUENCE.incrementAndGet()), LocalDateTime.class);
 	}
 
 	@Test

--- a/src/test/java/se/sundsvall/postportalservice/api/model/SigningInformationTest.java
+++ b/src/test/java/se/sundsvall/postportalservice/api/model/SigningInformationTest.java
@@ -1,7 +1,8 @@
 package se.sundsvall.postportalservice.api.model;
 
 import java.time.OffsetDateTime;
-import java.util.Random;
+import java.time.ZoneOffset;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -11,7 +12,6 @@ import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanHashCode;
 import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanToString;
 import static com.google.code.beanmatchers.BeanMatchers.hasValidGettersAndSetters;
 import static com.google.code.beanmatchers.BeanMatchers.registerValueGenerator;
-import static java.time.OffsetDateTime.now;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.allOf;
 
@@ -19,7 +19,8 @@ class SigningInformationTest {
 
 	// SigningInformation attributes
 	private static final String STATUS = "status";
-	private static final OffsetDateTime SIGNED_AT = now();
+	private static final OffsetDateTime SIGNED_AT = OffsetDateTime.of(2024, 6, 15, 12, 0, 0, 0, ZoneOffset.UTC);
+	private static final AtomicInteger SEQUENCE = new AtomicInteger();
 	private static final String CONTENT_KEY = "contentKey";
 	private static final String ORDER_REFERENCE = "orderReference";
 	private static final String SIGNATURE = "signature";
@@ -39,7 +40,7 @@ class SigningInformationTest {
 
 	@BeforeAll
 	static void setup() {
-		registerValueGenerator(() -> now().plusDays(new Random().nextInt()), OffsetDateTime.class);
+		registerValueGenerator(() -> SIGNED_AT.plusDays(SEQUENCE.incrementAndGet()), OffsetDateTime.class);
 	}
 
 	@Test

--- a/src/test/java/se/sundsvall/postportalservice/api/model/SigningInformationTest.java
+++ b/src/test/java/se/sundsvall/postportalservice/api/model/SigningInformationTest.java
@@ -1,7 +1,6 @@
 package se.sundsvall.postportalservice.api.model;
 
 import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -12,6 +11,7 @@ import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanHashCode;
 import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanToString;
 import static com.google.code.beanmatchers.BeanMatchers.hasValidGettersAndSetters;
 import static com.google.code.beanmatchers.BeanMatchers.registerValueGenerator;
+import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.allOf;
 
@@ -19,7 +19,7 @@ class SigningInformationTest {
 
 	// SigningInformation attributes
 	private static final String STATUS = "status";
-	private static final OffsetDateTime SIGNED_AT = OffsetDateTime.of(2024, 6, 15, 12, 0, 0, 0, ZoneOffset.UTC);
+	private static final OffsetDateTime SIGNED_AT = OffsetDateTime.of(2024, 6, 15, 12, 0, 0, 0, UTC);
 	private static final AtomicInteger SEQUENCE = new AtomicInteger();
 	private static final String CONTENT_KEY = "contentKey";
 	private static final String ORDER_REFERENCE = "orderReference";

--- a/src/test/java/se/sundsvall/postportalservice/integration/db/AttachmentEntityTest.java
+++ b/src/test/java/se/sundsvall/postportalservice/integration/db/AttachmentEntityTest.java
@@ -2,7 +2,6 @@ package se.sundsvall.postportalservice.integration.db;
 
 import java.sql.Blob;
 import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -14,6 +13,7 @@ import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanHashCode;
 import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanToString;
 import static com.google.code.beanmatchers.BeanMatchers.hasValidGettersAndSetters;
 import static com.google.code.beanmatchers.BeanMatchers.registerValueGenerator;
+import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -24,7 +24,7 @@ class AttachmentEntityTest {
 	private static final String FILE_NAME = "attachment.txt";
 	private static final String CONTENT_TYPE = "text/plain";
 	private static final String CONTENT_STRING = "contentString";
-	private static final OffsetDateTime CREATED = OffsetDateTime.of(2024, 6, 15, 12, 0, 0, 0, ZoneOffset.UTC);
+	private static final OffsetDateTime CREATED = OffsetDateTime.of(2024, 6, 15, 12, 0, 0, 0, UTC);
 	private static final AtomicInteger SEQUENCE = new AtomicInteger();
 	private final Blob blobMock = Mockito.mock(Blob.class);
 

--- a/src/test/java/se/sundsvall/postportalservice/integration/db/AttachmentEntityTest.java
+++ b/src/test/java/se/sundsvall/postportalservice/integration/db/AttachmentEntityTest.java
@@ -2,7 +2,8 @@ package se.sundsvall.postportalservice.integration.db;
 
 import java.sql.Blob;
 import java.time.OffsetDateTime;
-import java.util.Random;
+import java.time.ZoneOffset;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -13,7 +14,6 @@ import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanHashCode;
 import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanToString;
 import static com.google.code.beanmatchers.BeanMatchers.hasValidGettersAndSetters;
 import static com.google.code.beanmatchers.BeanMatchers.registerValueGenerator;
-import static java.time.OffsetDateTime.now;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -24,12 +24,13 @@ class AttachmentEntityTest {
 	private static final String FILE_NAME = "attachment.txt";
 	private static final String CONTENT_TYPE = "text/plain";
 	private static final String CONTENT_STRING = "contentString";
-	private static final OffsetDateTime CREATED = now();
+	private static final OffsetDateTime CREATED = OffsetDateTime.of(2024, 6, 15, 12, 0, 0, 0, ZoneOffset.UTC);
+	private static final AtomicInteger SEQUENCE = new AtomicInteger();
 	private final Blob blobMock = Mockito.mock(Blob.class);
 
 	@BeforeAll
 	static void setup() {
-		registerValueGenerator(() -> now().plusDays(new Random().nextInt()), OffsetDateTime.class);
+		registerValueGenerator(() -> CREATED.plusDays(SEQUENCE.incrementAndGet()), OffsetDateTime.class);
 	}
 
 	@Test

--- a/src/test/java/se/sundsvall/postportalservice/integration/db/MessageEntityTest.java
+++ b/src/test/java/se/sundsvall/postportalservice/integration/db/MessageEntityTest.java
@@ -1,8 +1,9 @@
 package se.sundsvall.postportalservice.integration.db;
 
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
-import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import se.sundsvall.postportalservice.integration.db.converter.MessageType;
@@ -13,7 +14,6 @@ import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanHashCodeExcl
 import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanToStringExcluding;
 import static com.google.code.beanmatchers.BeanMatchers.hasValidGettersAndSetters;
 import static com.google.code.beanmatchers.BeanMatchers.registerValueGenerator;
-import static java.time.OffsetDateTime.now;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -27,11 +27,12 @@ class MessageEntityTest {
 	private static final String BODY = "body";
 	private static final String CONTENT_TYPE = "contentType";
 	private static final String SUBJECT = "subject";
-	private static final OffsetDateTime CREATED = now();
+	private static final OffsetDateTime CREATED = OffsetDateTime.of(2024, 6, 15, 12, 0, 0, 0, ZoneOffset.UTC);
+	private static final AtomicInteger SEQUENCE = new AtomicInteger();
 
 	@BeforeAll
 	static void setup() {
-		registerValueGenerator(() -> now().plusDays(new Random().nextInt()), OffsetDateTime.class);
+		registerValueGenerator(() -> CREATED.plusDays(SEQUENCE.incrementAndGet()), OffsetDateTime.class);
 	}
 
 	@Test

--- a/src/test/java/se/sundsvall/postportalservice/integration/db/MessageEntityTest.java
+++ b/src/test/java/se/sundsvall/postportalservice/integration/db/MessageEntityTest.java
@@ -1,7 +1,6 @@
 package se.sundsvall.postportalservice.integration.db;
 
 import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeAll;
@@ -14,6 +13,7 @@ import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanHashCodeExcl
 import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanToStringExcluding;
 import static com.google.code.beanmatchers.BeanMatchers.hasValidGettersAndSetters;
 import static com.google.code.beanmatchers.BeanMatchers.registerValueGenerator;
+import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -27,7 +27,7 @@ class MessageEntityTest {
 	private static final String BODY = "body";
 	private static final String CONTENT_TYPE = "contentType";
 	private static final String SUBJECT = "subject";
-	private static final OffsetDateTime CREATED = OffsetDateTime.of(2024, 6, 15, 12, 0, 0, 0, ZoneOffset.UTC);
+	private static final OffsetDateTime CREATED = OffsetDateTime.of(2024, 6, 15, 12, 0, 0, 0, UTC);
 	private static final AtomicInteger SEQUENCE = new AtomicInteger();
 
 	@BeforeAll

--- a/src/test/java/se/sundsvall/postportalservice/integration/db/RecipientEntityTest.java
+++ b/src/test/java/se/sundsvall/postportalservice/integration/db/RecipientEntityTest.java
@@ -1,7 +1,6 @@
 package se.sundsvall.postportalservice.integration.db;
 
 import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -14,6 +13,7 @@ import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanHashCode;
 import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanToString;
 import static com.google.code.beanmatchers.BeanMatchers.hasValidGettersAndSetters;
 import static com.google.code.beanmatchers.BeanMatchers.registerValueGenerator;
+import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -38,7 +38,7 @@ class RecipientEntityTest {
 	private static final String MESSAGE_STATUS = "SENT";
 	private static final MessageType MESSAGE_TYPE = MessageType.SNAIL_MAIL;
 	private static final PartyType PARTY_TYPE = PartyType.PRIVATE;
-	private static final OffsetDateTime CREATED = OffsetDateTime.of(2024, 6, 15, 12, 0, 0, 0, ZoneOffset.UTC);
+	private static final OffsetDateTime CREATED = OffsetDateTime.of(2024, 6, 15, 12, 0, 0, 0, UTC);
 	private static final AtomicInteger SEQUENCE = new AtomicInteger();
 
 	@BeforeAll

--- a/src/test/java/se/sundsvall/postportalservice/integration/db/RecipientEntityTest.java
+++ b/src/test/java/se/sundsvall/postportalservice/integration/db/RecipientEntityTest.java
@@ -1,7 +1,8 @@
 package se.sundsvall.postportalservice.integration.db;
 
 import java.time.OffsetDateTime;
-import java.util.Random;
+import java.time.ZoneOffset;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import se.sundsvall.postportalservice.integration.db.converter.MessageType;
@@ -13,7 +14,6 @@ import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanHashCode;
 import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanToString;
 import static com.google.code.beanmatchers.BeanMatchers.hasValidGettersAndSetters;
 import static com.google.code.beanmatchers.BeanMatchers.registerValueGenerator;
-import static java.time.OffsetDateTime.now;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -38,11 +38,12 @@ class RecipientEntityTest {
 	private static final String MESSAGE_STATUS = "SENT";
 	private static final MessageType MESSAGE_TYPE = MessageType.SNAIL_MAIL;
 	private static final PartyType PARTY_TYPE = PartyType.PRIVATE;
-	private static final OffsetDateTime CREATED = now();
+	private static final OffsetDateTime CREATED = OffsetDateTime.of(2024, 6, 15, 12, 0, 0, 0, ZoneOffset.UTC);
+	private static final AtomicInteger SEQUENCE = new AtomicInteger();
 
 	@BeforeAll
 	static void setup() {
-		registerValueGenerator(() -> now().plusDays(new Random().nextInt()), OffsetDateTime.class);
+		registerValueGenerator(() -> CREATED.plusDays(SEQUENCE.incrementAndGet()), OffsetDateTime.class);
 	}
 
 	@Test

--- a/src/test/java/se/sundsvall/postportalservice/integration/digitalregisteredletter/DigitalRegisteredLetterMapperTest.java
+++ b/src/test/java/se/sundsvall/postportalservice/integration/digitalregisteredletter/DigitalRegisteredLetterMapperTest.java
@@ -224,7 +224,7 @@ class DigitalRegisteredLetterMapperTest {
 	@Test
 	void toSigningInformation() {
 		final var status = "COMPLETED";
-		final var signed = OffsetDateTime.now();
+		final var signed = OffsetDateTime.of(2024, 6, 15, 12, 0, 0, 0, java.time.ZoneOffset.UTC);
 		final var contentKey = "contentKey";
 		final var orderRef = "orderRef";
 		final var signature = "signature";

--- a/src/test/java/se/sundsvall/postportalservice/integration/digitalregisteredletter/DigitalRegisteredLetterMapperTest.java
+++ b/src/test/java/se/sundsvall/postportalservice/integration/digitalregisteredletter/DigitalRegisteredLetterMapperTest.java
@@ -21,6 +21,7 @@ import se.sundsvall.postportalservice.integration.db.DepartmentEntity;
 import se.sundsvall.postportalservice.integration.db.MessageEntity;
 import se.sundsvall.postportalservice.integration.db.RecipientEntity;
 
+import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
@@ -224,7 +225,7 @@ class DigitalRegisteredLetterMapperTest {
 	@Test
 	void toSigningInformation() {
 		final var status = "COMPLETED";
-		final var signed = OffsetDateTime.of(2024, 6, 15, 12, 0, 0, 0, java.time.ZoneOffset.UTC);
+		final var signed = OffsetDateTime.of(2024, 6, 15, 12, 0, 0, 0, UTC);
 		final var contentKey = "contentKey";
 		final var orderRef = "orderRef";
 		final var signature = "signature";

--- a/src/test/java/se/sundsvall/postportalservice/service/HistoryServiceTest.java
+++ b/src/test/java/se/sundsvall/postportalservice/service/HistoryServiceTest.java
@@ -2,7 +2,6 @@ package se.sundsvall.postportalservice.service;
 
 import generated.se.sundsvall.digitalregisteredletter.LetterStatus;
 import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -33,6 +32,7 @@ import se.sundsvall.postportalservice.integration.digitalregisteredletter.Digita
 import se.sundsvall.postportalservice.integration.party.PartyIntegration;
 import se.sundsvall.postportalservice.service.mapper.HistoryMapper;
 
+import static java.time.ZoneOffset.UTC;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -51,7 +51,7 @@ import static se.sundsvall.postportalservice.integration.db.converter.MessageTyp
 @ExtendWith(MockitoExtension.class)
 class HistoryServiceTest {
 
-	private static final OffsetDateTime FIXED_CREATED = OffsetDateTime.of(2024, 6, 15, 12, 0, 0, 0, ZoneOffset.UTC);
+	private static final OffsetDateTime FIXED_CREATED = OffsetDateTime.of(2024, 6, 15, 12, 0, 0, 0, UTC);
 
 	@Mock
 	private Page<MessageEntity> pageMock;

--- a/src/test/java/se/sundsvall/postportalservice/service/HistoryServiceTest.java
+++ b/src/test/java/se/sundsvall/postportalservice/service/HistoryServiceTest.java
@@ -2,6 +2,7 @@ package se.sundsvall.postportalservice.service;
 
 import generated.se.sundsvall.digitalregisteredletter.LetterStatus;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -50,6 +51,8 @@ import static se.sundsvall.postportalservice.integration.db.converter.MessageTyp
 @ExtendWith(MockitoExtension.class)
 class HistoryServiceTest {
 
+	private static final OffsetDateTime FIXED_CREATED = OffsetDateTime.of(2024, 6, 15, 12, 0, 0, 0, ZoneOffset.UTC);
+
 	@Mock
 	private Page<MessageEntity> pageMock;
 
@@ -78,7 +81,7 @@ class HistoryServiceTest {
 	void getUserMessages_noDigitalRegisteredLettersCommunication(final MessageType messageType) {
 		final var username = "username";
 		final var messageEntity = MessageEntity.create()
-			.withCreated(OffsetDateTime.now())
+			.withCreated(FIXED_CREATED)
 			.withSubject("subject")
 			.withMessageType(messageType)
 			.withId("id");
@@ -126,7 +129,7 @@ class HistoryServiceTest {
 		final var signingProcessState = "signingProcessState";
 		final var recipientEntity = new RecipientEntity().withExternalId(letterId);
 		final var messageEntity = MessageEntity.create()
-			.withCreated(OffsetDateTime.now())
+			.withCreated(FIXED_CREATED)
 			.withSubject("subject")
 			.withMessageType(MessageType.DIGITAL_REGISTERED_LETTER)
 			.withId(messageId)
@@ -188,7 +191,7 @@ class HistoryServiceTest {
 		final var status = "COMPLETED";
 		final var recipientEntity = new RecipientEntity().withExternalId(letterId);
 		final var messageEntity = MessageEntity.create()
-			.withCreated(OffsetDateTime.now())
+			.withCreated(FIXED_CREATED)
 			.withSubject("subject")
 			.withMessageType(MessageType.DIGITAL_REGISTERED_LETTER)
 			.withId(messageId)
@@ -245,7 +248,7 @@ class HistoryServiceTest {
 	void getUserMessages_digitalRegisteredLetterWithMissingRecipientData(final String description, final List<RecipientEntity> recipients) {
 		final var username = "username";
 		final var messageEntity = MessageEntity.create()
-			.withCreated(OffsetDateTime.now())
+			.withCreated(FIXED_CREATED)
 			.withSubject("subject")
 			.withMessageType(MessageType.DIGITAL_REGISTERED_LETTER)
 			.withId("messageId")
@@ -286,7 +289,7 @@ class HistoryServiceTest {
 		final var partyId = "partyId123";
 		final var message = MessageEntity.create()
 			.withSubject("subject")
-			.withCreated(OffsetDateTime.now())
+			.withCreated(FIXED_CREATED)
 			.withAttachments(List.of())
 			.withRecipients(List.of(new RecipientEntity().withPartyId(partyId)));
 
@@ -338,7 +341,7 @@ class HistoryServiceTest {
 		final var recipientEntity = new RecipientEntity().withPartyId(partyId).withExternalId(letterId);
 		final var message = MessageEntity.create()
 			.withSubject("subject")
-			.withCreated(OffsetDateTime.now())
+			.withCreated(FIXED_CREATED)
 			.withAttachments(List.of())
 			.withRecipients(List.of(recipientEntity))
 			.withMessageType(DIGITAL_REGISTERED_LETTER)
@@ -385,7 +388,7 @@ class HistoryServiceTest {
 		final var recipientEntity = new RecipientEntity().withPartyId(partyId).withExternalId(letterId);
 		final var message = MessageEntity.create()
 			.withSubject("subject")
-			.withCreated(OffsetDateTime.now())
+			.withCreated(FIXED_CREATED)
 			.withAttachments(List.of())
 			.withRecipients(List.of(recipientEntity))
 			.withMessageType(DIGITAL_REGISTERED_LETTER)
@@ -425,7 +428,7 @@ class HistoryServiceTest {
 		final var recipientWithoutPartyId = new RecipientEntity().withPartyId(null).withPhoneNumber("+46701740610");
 		final var message = MessageEntity.create()
 			.withSubject("subject")
-			.withCreated(OffsetDateTime.now())
+			.withCreated(FIXED_CREATED)
 			.withAttachments(List.of())
 			.withRecipients(List.of(recipientWithPartyId1, recipientWithoutPartyId, recipientWithPartyId2));
 
@@ -469,7 +472,7 @@ class HistoryServiceTest {
 		final var smsRecipient2 = new RecipientEntity().withPartyId(null).withPhoneNumber("+46701740620");
 		final var message = MessageEntity.create()
 			.withSubject("subject")
-			.withCreated(OffsetDateTime.now())
+			.withCreated(FIXED_CREATED)
 			.withAttachments(List.of())
 			.withRecipients(List.of(smsRecipient1, smsRecipient2));
 
@@ -506,7 +509,7 @@ class HistoryServiceTest {
 		final var recipient2 = new RecipientEntity().withPartyId(partyId2);
 		final var message = MessageEntity.create()
 			.withSubject("subject")
-			.withCreated(OffsetDateTime.now())
+			.withCreated(FIXED_CREATED)
 			.withAttachments(List.of())
 			.withRecipients(List.of(recipient1, recipient2));
 

--- a/src/test/java/se/sundsvall/postportalservice/service/mapper/HistoryMapperTest.java
+++ b/src/test/java/se/sundsvall/postportalservice/service/mapper/HistoryMapperTest.java
@@ -2,6 +2,7 @@ package se.sundsvall.postportalservice.service.mapper;
 
 import generated.se.sundsvall.digitalregisteredletter.LetterStatus;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -15,11 +16,12 @@ import static se.sundsvall.postportalservice.integration.db.converter.MessageTyp
 class HistoryMapperTest {
 
 	private static final HistoryMapper HISTORY_MAPPER = new HistoryMapper();
+	private static final OffsetDateTime FIXED_CREATED = OffsetDateTime.of(2024, 6, 15, 12, 0, 0, 0, ZoneOffset.UTC);
 
 	@Test
 	void toMessageList() {
 		// Setup
-		final var created = OffsetDateTime.now();
+		final var created = FIXED_CREATED;
 		final var id = "id";
 		final var messageType = DIGITAL_MAIL;
 		final var recipients = List.of(RecipientEntity.create(), RecipientEntity.create(), RecipientEntity.create());
@@ -49,7 +51,7 @@ class HistoryMapperTest {
 	@Test
 	void toMessageListWhenSourceContainsNull() {
 		// Setup
-		final var created = OffsetDateTime.now();
+		final var created = FIXED_CREATED;
 		final var id = "id";
 		final var messageType = DIGITAL_MAIL;
 		final var recipients = List.of(RecipientEntity.create());
@@ -87,7 +89,7 @@ class HistoryMapperTest {
 	@Test
 	void toMessage() {
 		// Setup
-		final var created = OffsetDateTime.now();
+		final var created = FIXED_CREATED;
 		final var id = "id";
 		final var messageType = DIGITAL_MAIL;
 		final var recipients = List.of(RecipientEntity.create(), RecipientEntity.create());
@@ -136,7 +138,7 @@ class HistoryMapperTest {
 		// Setup
 		final var subject = "subject";
 		final var body = "body";
-		final var created = OffsetDateTime.now();
+		final var created = FIXED_CREATED;
 		final var attachment = AttachmentEntity.create();
 		final var recipient = RecipientEntity.create();
 		final var messageEntity = MessageEntity.create()

--- a/src/test/java/se/sundsvall/postportalservice/service/mapper/HistoryMapperTest.java
+++ b/src/test/java/se/sundsvall/postportalservice/service/mapper/HistoryMapperTest.java
@@ -2,7 +2,6 @@ package se.sundsvall.postportalservice.service.mapper;
 
 import generated.se.sundsvall.digitalregisteredletter.LetterStatus;
 import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -10,13 +9,14 @@ import se.sundsvall.postportalservice.integration.db.AttachmentEntity;
 import se.sundsvall.postportalservice.integration.db.MessageEntity;
 import se.sundsvall.postportalservice.integration.db.RecipientEntity;
 
+import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static se.sundsvall.postportalservice.integration.db.converter.MessageType.DIGITAL_MAIL;
 
 class HistoryMapperTest {
 
 	private static final HistoryMapper HISTORY_MAPPER = new HistoryMapper();
-	private static final OffsetDateTime FIXED_CREATED = OffsetDateTime.of(2024, 6, 15, 12, 0, 0, 0, ZoneOffset.UTC);
+	private static final OffsetDateTime FIXED_CREATED = OffsetDateTime.of(2024, 6, 15, 12, 0, 0, 0, UTC);
 
 	@Test
 	void toMessageList() {

--- a/src/test/java/se/sundsvall/postportalservice/service/mapper/HistoryMapperTest.java
+++ b/src/test/java/se/sundsvall/postportalservice/service/mapper/HistoryMapperTest.java
@@ -402,6 +402,36 @@ class HistoryMapperTest {
 	}
 
 	@Test
+	void toRecipient_enterpriseUsesOrganizationName() {
+		final var recipientEntity = RecipientEntity.create()
+			.withOrganizationName("Acme AB")
+			.withMessageType(DIGITAL_MAIL)
+			.withPartyId("partyId")
+			.withStatus("status");
+
+		final var result = HISTORY_MAPPER.toRecipient(recipientEntity);
+
+		assertThat(result).isNotNull();
+		assertThat(result.getName()).isEqualTo("Acme AB");
+	}
+
+	@Test
+	void toRecipient_enterpriseWithContactPersonCombinesBoth() {
+		final var recipientEntity = RecipientEntity.create()
+			.withFirstName("John")
+			.withLastName("Doe")
+			.withOrganizationName("Acme AB")
+			.withMessageType(DIGITAL_MAIL)
+			.withPartyId("partyId")
+			.withStatus("status");
+
+		final var result = HISTORY_MAPPER.toRecipient(recipientEntity);
+
+		assertThat(result).isNotNull();
+		assertThat(result.getName()).isEqualTo("Acme AB (att: John Doe)");
+	}
+
+	@Test
 	void toRecipientFromNull() {
 		assertThat(HISTORY_MAPPER.toRecipient(null)).isNull();
 	}

--- a/src/test/java/se/sundsvall/postportalservice/service/util/StringUtilTest.java
+++ b/src/test/java/se/sundsvall/postportalservice/service/util/StringUtilTest.java
@@ -26,4 +26,20 @@ class StringUtilTest {
 			Arguments.of("Test of trimming values for both first and last name", " Shimada ", " Tyndall ", "Shimada Tyndall"),
 			Arguments.of("Test of trimming values for both complex first and complex last name", " Captain Soren ", " Bane Rhineheart ", "Captain Soren Bane Rhineheart"));
 	}
+
+	@ParameterizedTest(name = "{0}")
+	@MethodSource("calculateRecipientNameProvider")
+	void calculateRecipientName(String testName, String firstName, String lastName, String organizationName, String expectedResult) {
+		assertThat(StringUtil.calculateRecipientName(firstName, lastName, organizationName)).isEqualTo(expectedResult);
+	}
+
+	private static Stream<Arguments> calculateRecipientNameProvider() {
+		return Stream.of(
+			Arguments.of("Nothing set", null, null, null, null),
+			Arguments.of("Only organisation name", null, null, "Acme AB", "Acme AB"),
+			Arguments.of("Only person name", "John", "Doe", null, "John Doe"),
+			Arguments.of("Both organisation and person name", "John", "Doe", "Acme AB", "Acme AB (att: John Doe)"),
+			Arguments.of("Organisation name + only first name", "John", null, "Acme AB", "Acme AB (att: John)"),
+			Arguments.of("Blank organisation name falls back to person name", "John", "Doe", "  ", "John Doe"));
+	}
 }

--- a/src/test/java/se/sundsvall/postportalservice/util/LegalIdUtilTest.java
+++ b/src/test/java/se/sundsvall/postportalservice/util/LegalIdUtilTest.java
@@ -75,7 +75,9 @@ class LegalIdUtilTest {
 	}
 
 	public static Stream<Arguments> legalIdProvider() {
-		final var today = LocalDate.now();
+		// LegalIdUtil.isAnAdult uses LocalDate.now() to compute age; the test must use the same "today" so generated
+		// birth dates land on the expected side of the 18-year boundary.
+		final var today = LocalDate.now(); // NOSONAR
 		final var formatter = DateTimeFormatter.ofPattern("uuuuMMdd");  // Using strict mode in the actual implementation
 
 		// Dynamic dates


### PR DESCRIPTION
## Summary
- `HistoryMapper.toRecipient` only built `RecipientDetails.name` from `firstName`/`lastName`, so enterprise recipients (where only `organizationName` is populated) ended up with `name = null` in the history view.
- Extracted the shared name-building logic into `StringUtil.calculateRecipientName` so both `HistoryMapper` and `MessagingMapper.formatRecipientName` use a single source of truth: org + person → `"Acme AB (att: John Doe)"`, org only → `"Acme AB"`, person only → `"John Doe"`, nothing → `null`.

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No

## Checklist:

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if applicable).
- [x] I have added/updated tests to cover my changes (if applicable).