### PR TITLE
HYDRAN-2580: Download the signed document

### DIFF
--- a/src/integration-test/resources/api/openapi.yaml
+++ b/src/integration-test/resources/api/openapi.yaml
@@ -7,7 +7,7 @@ info:
     url: https://opensource.org/licenses/MIT
   version: "1.8"
 servers:
-- url: http://localhost:55292
+- url: http://localhost:59269
   description: Generated server url
 tags:
 - name: E-signing
@@ -824,6 +824,63 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SigningInformation"
+        "404":
+          description: Not Found
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "400":
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                - $ref: "#/components/schemas/Problem"
+                - $ref: "#/components/schemas/ConstraintViolationProblem"
+        "500":
+          description: Internal Server Error
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "502":
+          description: Bad Gateway
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+  /{municipalityId}/history/messages/{messageId}/signed-document:
+    get:
+      tags:
+      - History Resources
+      summary: Download the signed document for an e-signing message
+      description: Streams the signed (merged) PDF produced once the e-signing case
+        has completed
+      operationId: downloadSignedDocument
+      parameters:
+      - name: municipalityId
+        in: path
+        description: Municipality ID
+        required: true
+        schema:
+          type: string
+        example: 2281
+      - name: messageId
+        in: path
+        description: Message ID
+        required: true
+        schema:
+          type: string
+        example: 9ce333ec-a473-438b-8406-a71e957dc107
+      responses:
+        "200":
+          description: Successful Operation - OK
+          content:
+            '*/*':
+              schema:
+                type: string
+                format: binary
         "404":
           description: Not Found
           content:

--- a/src/integration-test/resources/api/openapi.yaml
+++ b/src/integration-test/resources/api/openapi.yaml
@@ -7,7 +7,7 @@ info:
     url: https://opensource.org/licenses/MIT
   version: "1.8"
 servers:
-- url: http://localhost:59269
+- url: http://localhost:52228
   description: Generated server url
 tags:
 - name: E-signing
@@ -534,15 +534,17 @@ paths:
               properties:
                 request:
                   $ref: "#/components/schemas/ESigningRequest"
+                document:
+                  type: string
+                  format: binary
                 attachments:
                   type: array
                   items:
                     type: string
                     format: binary
               required:
-              - attachments
+              - document
               - request
-        required: true
       responses:
         "200":
           description: OK

--- a/src/main/java/se/sundsvall/postportalservice/api/HistoryResource.java
+++ b/src/main/java/se/sundsvall/postportalservice/api/HistoryResource.java
@@ -93,4 +93,16 @@ class HistoryResource {
 		return historyService.getLetterReceipt(municipalityId, messageId);
 	}
 
+	@GetMapping(value = "/messages/{messageId}/signed-document", produces = ALL_VALUE)
+	@Operation(summary = "Download the signed document for an e-signing message", description = "Streams the signed (merged) PDF produced once the e-signing case has completed", responses = {
+		@ApiResponse(responseCode = "200", description = "Successful Operation - OK", content = @Content(mediaType = ALL_VALUE, schema = @Schema(type = "string", format = "binary"))),
+		@ApiResponse(responseCode = "404", description = "Not Found", content = @Content(mediaType = APPLICATION_PROBLEM_JSON_VALUE, schema = @Schema(implementation = Problem.class)))
+	})
+	ResponseEntity<StreamingResponseBody> downloadSignedDocument(
+		@Parameter(name = "municipalityId", description = "Municipality ID", example = "2281") @ValidMunicipalityId @PathVariable final String municipalityId,
+		@Parameter(name = "messageId", description = "Message ID", example = "9ce333ec-a473-438b-8406-a71e957dc107") @PathVariable @ValidUuid final String messageId) {
+
+		return historyService.getSignedDocument(municipalityId, messageId);
+	}
+
 }

--- a/src/main/java/se/sundsvall/postportalservice/service/HistoryService.java
+++ b/src/main/java/se/sundsvall/postportalservice/service/HistoryService.java
@@ -17,12 +17,16 @@ import se.sundsvall.postportalservice.api.model.Message;
 import se.sundsvall.postportalservice.api.model.MessageDetails;
 import se.sundsvall.postportalservice.api.model.Messages;
 import se.sundsvall.postportalservice.api.model.SigningInformation;
+import se.sundsvall.postportalservice.integration.db.AttachmentEntity;
 import se.sundsvall.postportalservice.integration.db.MessageEntity;
+import se.sundsvall.postportalservice.integration.db.SigningEntity;
 import se.sundsvall.postportalservice.integration.db.dao.MessageRepository;
+import se.sundsvall.postportalservice.integration.db.dao.SigningRepository;
 import se.sundsvall.postportalservice.integration.digitalregisteredletter.DigitalRegisteredLetterIntegration;
 import se.sundsvall.postportalservice.integration.party.PartyIntegration;
 import se.sundsvall.postportalservice.service.mapper.HistoryMapper;
 
+import static org.springframework.http.HttpHeaders.CONTENT_DISPOSITION;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static se.sundsvall.postportalservice.integration.db.converter.MessageType.DIGITAL_REGISTERED_LETTER;
 
@@ -30,15 +34,21 @@ import static se.sundsvall.postportalservice.integration.db.converter.MessageTyp
 public class HistoryService {
 	private final DigitalRegisteredLetterIntegration digitalRegisteredLetterIntegration;
 	private final MessageRepository messageRepository;
+	private final SigningRepository signingRepository;
+	private final AttachmentService attachmentService;
 	private final HistoryMapper historyMapper;
 	private final PartyIntegration partyIntegration;
 
 	public HistoryService(
 		final DigitalRegisteredLetterIntegration digitalRegisteredLetterIntegration,
 		final MessageRepository messageRepository,
+		final SigningRepository signingRepository,
+		final AttachmentService attachmentService,
 		final HistoryMapper historyMapper, final PartyIntegration partyIntegration) {
 		this.digitalRegisteredLetterIntegration = digitalRegisteredLetterIntegration;
 		this.messageRepository = messageRepository;
+		this.signingRepository = signingRepository;
+		this.attachmentService = attachmentService;
 		this.historyMapper = historyMapper;
 		this.partyIntegration = partyIntegration;
 	}
@@ -123,6 +133,25 @@ public class HistoryService {
 		final var letterId = getLetterIdFromMessage(message);
 
 		return digitalRegisteredLetterIntegration.getLetterReceipt(municipalityId, letterId);
+	}
+
+	/**
+	 * Streams the signed (merged) document for an e-signing message. The signed PDF is stored as an attachment the
+	 * signing case points at once the case completes; until then (or for a non-e-signing message) there is nothing to
+	 * download and a 404 is returned.
+	 */
+	public ResponseEntity<StreamingResponseBody> getSignedDocument(final String municipalityId, final String messageId) {
+		final var signedAttachmentId = signingRepository.findByMessageId(messageId)
+			.map(SigningEntity::getAttachment)
+			.map(AttachmentEntity::getId)
+			.orElseThrow(() -> Problem.valueOf(NOT_FOUND, "No signed document available for message with id '%s'".formatted(messageId)));
+
+		final var attachmentData = attachmentService.getAttachmentData(municipalityId, signedAttachmentId);
+
+		return ResponseEntity.ok()
+			.header(CONTENT_DISPOSITION, attachmentData.contentDisposition().toString())
+			.contentType(attachmentData.contentType())
+			.body(attachmentData.contentStream());
 	}
 
 	private MessageEntity getDigitalRegisteredLetterMessage(final String messageId) {

--- a/src/test/java/se/sundsvall/postportalservice/api/HistoryResourceFailureTest.java
+++ b/src/test/java/se/sundsvall/postportalservice/api/HistoryResourceFailureTest.java
@@ -130,4 +130,27 @@ class HistoryResourceFailureTest {
 			});
 	}
 
+	@Test
+	void downloadSignedDocument_badRequest() {
+		final var response = webTestClient.get()
+			.uri("/{municipalityId}/history/messages/{messageId}/signed-document", INVALID_MUNICIPALITY_ID, "invalid")
+			.exchange()
+			.expectStatus().isBadRequest()
+			.expectBody(ConstraintViolationProblem.class)
+			.returnResult()
+			.getResponseBody();
+
+		assertThat(response).isNotNull();
+		assertThat(response.getTitle()).isEqualTo("Constraint Violation");
+		assertThat(response.getViolations()).hasSize(2).satisfiesExactlyInAnyOrder(
+			violation -> {
+				assertThat(violation.field()).isEqualTo("downloadSignedDocument.municipalityId");
+				assertThat(violation.message()).isEqualTo("not a valid municipality ID");
+			},
+			violation -> {
+				assertThat(violation.field()).isEqualTo("downloadSignedDocument.messageId");
+				assertThat(violation.message()).isEqualTo("not a valid UUID");
+			});
+	}
+
 }

--- a/src/test/java/se/sundsvall/postportalservice/api/HistoryResourceTest.java
+++ b/src/test/java/se/sundsvall/postportalservice/api/HistoryResourceTest.java
@@ -212,4 +212,39 @@ class HistoryResourceTest {
 		verify(historyServiceMock).getLetterReceipt(MUNICIPALITY_ID, messageId);
 	}
 
+	@Test
+	void downloadSignedDocument() {
+		final var messageId = UUID.randomUUID().toString();
+		final var mockResponseEntity = ok()
+			.header("Content-Type", "application/pdf")
+			.body((StreamingResponseBody) outputStream -> outputStream.write("signed data".getBytes()));
+
+		when(historyServiceMock.getSignedDocument(MUNICIPALITY_ID, messageId)).thenReturn(mockResponseEntity);
+
+		final var bytes = webTestClient.get()
+			.uri("/{municipalityId}/history/messages/{messageId}/signed-document", MUNICIPALITY_ID, messageId)
+			.exchange()
+			.expectStatus().isOk()
+			.expectBody(byte[].class)
+			.returnResult()
+			.getResponseBody();
+
+		assertThat(bytes).isNotNull().isEqualTo("signed data".getBytes());
+		verify(historyServiceMock).getSignedDocument(MUNICIPALITY_ID, messageId);
+	}
+
+	@Test
+	void downloadSignedDocument_notFound() {
+		final var messageId = UUID.randomUUID().toString();
+
+		when(historyServiceMock.getSignedDocument(MUNICIPALITY_ID, messageId)).thenThrow(Problem.valueOf(NOT_FOUND));
+
+		webTestClient.get()
+			.uri("/{municipalityId}/history/messages/{messageId}/signed-document", MUNICIPALITY_ID, messageId)
+			.exchange()
+			.expectStatus().isNotFound();
+
+		verify(historyServiceMock).getSignedDocument(MUNICIPALITY_ID, messageId);
+	}
+
 }

--- a/src/test/java/se/sundsvall/postportalservice/service/HistoryServiceTest.java
+++ b/src/test/java/se/sundsvall/postportalservice/service/HistoryServiceTest.java
@@ -20,14 +20,18 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.http.ContentDisposition;
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 import se.sundsvall.dept44.problem.Problem;
 import se.sundsvall.postportalservice.api.model.SigningInformation;
 import se.sundsvall.postportalservice.api.model.SigningStatus;
+import se.sundsvall.postportalservice.integration.db.AttachmentEntity;
 import se.sundsvall.postportalservice.integration.db.MessageEntity;
 import se.sundsvall.postportalservice.integration.db.RecipientEntity;
+import se.sundsvall.postportalservice.integration.db.SigningEntity;
 import se.sundsvall.postportalservice.integration.db.converter.MessageType;
 import se.sundsvall.postportalservice.integration.db.dao.MessageRepository;
+import se.sundsvall.postportalservice.integration.db.dao.SigningRepository;
 import se.sundsvall.postportalservice.integration.digitalregisteredletter.DigitalRegisteredLetterIntegration;
 import se.sundsvall.postportalservice.integration.party.PartyIntegration;
 import se.sundsvall.postportalservice.service.mapper.HistoryMapper;
@@ -44,6 +48,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpHeaders.CONTENT_DISPOSITION;
+import static org.springframework.http.HttpStatus.OK;
+import static org.springframework.http.MediaType.APPLICATION_PDF;
 import static org.springframework.http.ResponseEntity.ok;
 import static se.sundsvall.postportalservice.TestDataFactory.MUNICIPALITY_ID;
 import static se.sundsvall.postportalservice.integration.db.converter.MessageType.DIGITAL_REGISTERED_LETTER;
@@ -68,12 +75,18 @@ class HistoryServiceTest {
 	@Mock
 	private PartyIntegration partyIntegrationMock;
 
+	@Mock
+	private SigningRepository signingRepositoryMock;
+
+	@Mock
+	private AttachmentService attachmentServiceMock;
+
 	@InjectMocks
 	private HistoryService historyService;
 
 	@AfterEach
 	void ensureNoUnexpectedMockInteractions() {
-		verifyNoMoreInteractions(messageRepositoryMock, pageMock, historyMapperMock, digitalRegisteredLetterIntegrationMock, partyIntegrationMock);
+		verifyNoMoreInteractions(messageRepositoryMock, pageMock, historyMapperMock, digitalRegisteredLetterIntegrationMock, partyIntegrationMock, signingRepositoryMock, attachmentServiceMock);
 	}
 
 	@ParameterizedTest
@@ -606,6 +619,54 @@ class HistoryServiceTest {
 		verify(messageRepositoryMock).findByIdAndMessageType(messageId, DIGITAL_REGISTERED_LETTER);
 		verify(digitalRegisteredLetterIntegrationMock).getLetterReceipt(MUNICIPALITY_ID, externalId);
 		verifyNoMoreInteractions(messageRepositoryMock, digitalRegisteredLetterIntegrationMock);
+	}
+
+	@Test
+	void getSignedDocument() {
+		final var messageId = "messageId";
+		final var attachmentId = "attachmentId";
+		final var signing = SigningEntity.create().withAttachment(new AttachmentEntity().withId(attachmentId));
+		final StreamingResponseBody stream = outputStream -> outputStream.write("signed".getBytes());
+		final var contentDisposition = ContentDisposition.attachment().filename("signed.pdf").build();
+		final var attachmentData = new AttachmentService.AttachmentData(contentDisposition, APPLICATION_PDF, stream);
+
+		when(signingRepositoryMock.findByMessageId(messageId)).thenReturn(Optional.of(signing));
+		when(attachmentServiceMock.getAttachmentData(MUNICIPALITY_ID, attachmentId)).thenReturn(attachmentData);
+
+		final var result = historyService.getSignedDocument(MUNICIPALITY_ID, messageId);
+
+		assertThat(result.getStatusCode()).isEqualTo(OK);
+		assertThat(result.getHeaders().getFirst(CONTENT_DISPOSITION)).isEqualTo(contentDisposition.toString());
+		assertThat(result.getHeaders().getContentType()).isEqualTo(APPLICATION_PDF);
+		assertThat(result.getBody()).isSameAs(stream);
+		verify(signingRepositoryMock).findByMessageId(messageId);
+		verify(attachmentServiceMock).getAttachmentData(MUNICIPALITY_ID, attachmentId);
+	}
+
+	@Test
+	void getSignedDocument_noSigningCase() {
+		final var messageId = "messageId";
+		when(signingRepositoryMock.findByMessageId(messageId)).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> historyService.getSignedDocument(MUNICIPALITY_ID, messageId))
+			.isInstanceOf(Problem.class)
+			.hasMessageContaining("Not Found: No signed document available for message with id '%s'".formatted(messageId));
+
+		verify(signingRepositoryMock).findByMessageId(messageId);
+		verifyNoInteractions(attachmentServiceMock);
+	}
+
+	@Test
+	void getSignedDocument_notSignedYet() {
+		final var messageId = "messageId";
+		when(signingRepositoryMock.findByMessageId(messageId)).thenReturn(Optional.of(SigningEntity.create()));
+
+		assertThatThrownBy(() -> historyService.getSignedDocument(MUNICIPALITY_ID, messageId))
+			.isInstanceOf(Problem.class)
+			.hasMessageContaining("Not Found: No signed document available for message with id '%s'".formatted(messageId));
+
+		verify(signingRepositoryMock).findByMessageId(messageId);
+		verifyNoInteractions(attachmentServiceMock);
 	}
 
 }


### PR DESCRIPTION
Adds `GET /{municipalityId}/history/messages/{messageId}/signed-document` which streams the signed (merged) PDF produced once an e-signing case completes.

- Mirrors the existing letter-`receipt` endpoint; delegates streaming to `AttachmentService.getAttachmentData`.
- Reaches the signed attachment via `SigningRepository.findByMessageId(..)` → `signing.getAttachment()`.
- 404 when the message has no signing case or the case is not yet signed.
- Full unit coverage (service happy + 2×not-found, resource happy/not-found/bad-request); OpenAPI contract regenerated.

Stacked on #100 (`feature/esigning-consume`).