### PR TITLE
HYDRAN-2582: Cancel an ongoing e-signing

### DIFF
--- a/src/integration-test/resources/api/openapi.yaml
+++ b/src/integration-test/resources/api/openapi.yaml
@@ -7,7 +7,7 @@ info:
     url: https://opensource.org/licenses/MIT
   version: "1.8"
 servers:
-- url: http://localhost:55292
+- url: http://localhost:54002
   description: Generated server url
 tags:
 - name: E-signing

--- a/src/integration-test/resources/api/openapi.yaml
+++ b/src/integration-test/resources/api/openapi.yaml
@@ -7,7 +7,7 @@ info:
     url: https://opensource.org/licenses/MIT
   version: "1.8"
 servers:
-- url: http://localhost:50387
+- url: http://localhost:55292
   description: Generated server url
 tags:
 - name: E-signing
@@ -976,6 +976,56 @@ paths:
       x-auth-type: None
       x-throttling-tier: Unlimited
       x-wso2-mutual-ssl: Optional
+  /{municipalityId}/messages/e-signing/{messageId}:
+    delete:
+      tags:
+      - Message Resources
+      summary: Cancel an ongoing Comfact e-signing.
+      operationId: cancelESigning
+      parameters:
+      - name: municipalityId
+        in: path
+        description: Municipality ID
+        required: true
+        schema:
+          type: string
+        example: 2281
+      - name: messageId
+        in: path
+        description: Message ID
+        required: true
+        schema:
+          type: string
+        example: 9ce333ec-a473-438b-8406-a71e957dc107
+      responses:
+        "204":
+          description: No Content
+        "404":
+          description: Not Found
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "400":
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                - $ref: "#/components/schemas/Problem"
+                - $ref: "#/components/schemas/ConstraintViolationProblem"
+        "500":
+          description: Internal Server Error
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "502":
+          description: Bad Gateway
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
 components:
   schemas:
     PrecheckRequest:

--- a/src/integration-test/resources/api/openapi.yaml
+++ b/src/integration-test/resources/api/openapi.yaml
@@ -7,7 +7,7 @@ info:
     url: https://opensource.org/licenses/MIT
   version: "1.8"
 servers:
-- url: http://localhost:55292
+- url: http://localhost:51240
   description: Generated server url
 tags:
 - name: E-signing
@@ -974,6 +974,56 @@ paths:
       x-auth-type: None
       x-throttling-tier: Unlimited
       x-wso2-mutual-ssl: Optional
+  /{municipalityId}/messages/e-signing/{messageId}:
+    delete:
+      tags:
+      - Message Resources
+      summary: Cancel an ongoing Comfact e-signing.
+      operationId: cancelESigning
+      parameters:
+      - name: municipalityId
+        in: path
+        description: Municipality ID
+        required: true
+        schema:
+          type: string
+        example: 2281
+      - name: messageId
+        in: path
+        description: Message ID
+        required: true
+        schema:
+          type: string
+        example: 9ce333ec-a473-438b-8406-a71e957dc107
+      responses:
+        "204":
+          description: No Content
+        "404":
+          description: Not Found
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "400":
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                - $ref: "#/components/schemas/Problem"
+                - $ref: "#/components/schemas/ConstraintViolationProblem"
+        "500":
+          description: Internal Server Error
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "502":
+          description: Bad Gateway
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
 components:
   schemas:
     PrecheckRequest:

--- a/src/main/java/se/sundsvall/postportalservice/Constants.java
+++ b/src/main/java/se/sundsvall/postportalservice/Constants.java
@@ -13,6 +13,8 @@ public final class Constants {
 
 	// E-signing case status (mirrors the normalized status from api-service-e-signing). SIGNERAT is terminal.
 	public static final String SIGNERAT = "SIGNERAT";
+	// Terminal error/cancelled state (Comfact 'withdrawn'/'declined'/'halted' all normalize to FEL in e-signing).
+	public static final String FEL = "FEL";
 
 	// E-signing recipient (signatory) status
 	public static final String SIGNED = "SIGNED";

--- a/src/main/java/se/sundsvall/postportalservice/Constants.java
+++ b/src/main/java/se/sundsvall/postportalservice/Constants.java
@@ -5,6 +5,7 @@ public final class Constants {
 	private Constants() {}
 
 	public static final String ORIGIN = "PostPortalService";
+	public static final String CANCELLED = "CANCELLED";
 	public static final String FAILED = "FAILED";
 	public static final String PENDING = "PENDING";
 	public static final String SENT = "SENT";

--- a/src/main/java/se/sundsvall/postportalservice/api/MessageResource.java
+++ b/src/main/java/se/sundsvall/postportalservice/api/MessageResource.java
@@ -12,6 +12,7 @@ import jakarta.validation.constraints.NotEmpty;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import se.sundsvall.dept44.common.validators.annotation.ValidMunicipalityId;
+import se.sundsvall.dept44.common.validators.annotation.ValidUuid;
 import se.sundsvall.dept44.problem.Problem;
 import se.sundsvall.dept44.support.Identifier;
 import se.sundsvall.postportalservice.api.model.DigitalRegisteredLetterRequest;
@@ -40,6 +42,7 @@ import static org.springframework.http.MediaType.ALL_VALUE;
 import static org.springframework.http.MediaType.APPLICATION_PROBLEM_JSON_VALUE;
 import static org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE;
 import static org.springframework.http.ResponseEntity.created;
+import static org.springframework.http.ResponseEntity.noContent;
 import static org.springframework.web.util.UriComponentsBuilder.fromPath;
 
 @Validated
@@ -135,6 +138,20 @@ class MessageResource {
 			.buildAndExpand(municipalityId, Identifier.get().getValue(), messageId).toUri())
 			.header(CONTENT_TYPE, ALL_VALUE)
 			.build();
+	}
+
+	@Operation(summary = "Cancel an ongoing Comfact e-signing.", responses = {
+		@ApiResponse(responseCode = "204", description = "No Content"),
+		@ApiResponse(responseCode = "404", description = "Not Found", content = @Content(mediaType = APPLICATION_PROBLEM_JSON_VALUE, schema = @Schema(implementation = Problem.class)))
+	})
+	@DeleteMapping(value = "/e-signing/{messageId}", produces = ALL_VALUE)
+	ResponseEntity<Void> cancelESigning(
+		@Parameter(name = "municipalityId", description = "Municipality ID", example = "2281") @ValidMunicipalityId @PathVariable final String municipalityId,
+		@Parameter(name = "messageId", description = "Message ID", example = "9ce333ec-a473-438b-8406-a71e957dc107") @PathVariable @ValidUuid final String messageId) {
+
+		messageService.cancelESigning(municipalityId, messageId);
+
+		return noContent().build();
 	}
 
 	@Operation(summary = "Send an SMS", responses = {

--- a/src/main/java/se/sundsvall/postportalservice/api/MessageResource.java
+++ b/src/main/java/se/sundsvall/postportalservice/api/MessageResource.java
@@ -12,6 +12,7 @@ import jakarta.validation.constraints.NotEmpty;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import se.sundsvall.dept44.common.validators.annotation.ValidMunicipalityId;
+import se.sundsvall.dept44.common.validators.annotation.ValidUuid;
 import se.sundsvall.dept44.problem.Problem;
 import se.sundsvall.dept44.support.Identifier;
 import se.sundsvall.postportalservice.api.model.DigitalRegisteredLetterRequest;
@@ -40,6 +42,7 @@ import static org.springframework.http.MediaType.ALL_VALUE;
 import static org.springframework.http.MediaType.APPLICATION_PROBLEM_JSON_VALUE;
 import static org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE;
 import static org.springframework.http.ResponseEntity.created;
+import static org.springframework.http.ResponseEntity.noContent;
 import static org.springframework.web.util.UriComponentsBuilder.fromPath;
 
 @Validated
@@ -136,6 +139,20 @@ class MessageResource {
 			.buildAndExpand(municipalityId, Identifier.get().getValue(), messageId).toUri())
 			.header(CONTENT_TYPE, ALL_VALUE)
 			.build();
+	}
+
+	@Operation(summary = "Cancel an ongoing Comfact e-signing.", responses = {
+		@ApiResponse(responseCode = "204", description = "No Content"),
+		@ApiResponse(responseCode = "404", description = "Not Found", content = @Content(mediaType = APPLICATION_PROBLEM_JSON_VALUE, schema = @Schema(implementation = Problem.class)))
+	})
+	@DeleteMapping(value = "/e-signing/{messageId}", produces = ALL_VALUE)
+	ResponseEntity<Void> cancelESigning(
+		@Parameter(name = "municipalityId", description = "Municipality ID", example = "2281") @ValidMunicipalityId @PathVariable final String municipalityId,
+		@Parameter(name = "messageId", description = "Message ID", example = "9ce333ec-a473-438b-8406-a71e957dc107") @PathVariable @ValidUuid final String messageId) {
+
+		messageService.cancelESigning(municipalityId, messageId);
+
+		return noContent().build();
 	}
 
 	@Operation(summary = "Send an SMS", responses = {

--- a/src/main/java/se/sundsvall/postportalservice/integration/esigning/EsigningClient.java
+++ b/src/main/java/se/sundsvall/postportalservice/integration/esigning/EsigningClient.java
@@ -4,6 +4,7 @@ import generated.se.sundsvall.esigning.StartSigningRequest;
 import generated.se.sundsvall.esigning.StartSigningResponse;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -23,5 +24,10 @@ public interface EsigningClient {
 	StartSigningResponse createSigning(
 		@PathVariable final String municipalityId,
 		@RequestBody final StartSigningRequest request);
+
+	@DeleteMapping(path = "/{municipalityId}/e-signing/signings/{providerCaseId}")
+	void cancelSigning(
+		@PathVariable final String municipalityId,
+		@PathVariable final String providerCaseId);
 
 }

--- a/src/main/java/se/sundsvall/postportalservice/integration/esigning/EsigningIntegration.java
+++ b/src/main/java/se/sundsvall/postportalservice/integration/esigning/EsigningIntegration.java
@@ -17,4 +17,8 @@ public class EsigningIntegration {
 		return client.createSigning(municipalityId, request);
 	}
 
+	public void cancelSigning(final String municipalityId, final String providerCaseId) {
+		client.cancelSigning(municipalityId, providerCaseId);
+	}
+
 }

--- a/src/main/java/se/sundsvall/postportalservice/service/MessageService.java
+++ b/src/main/java/se/sundsvall/postportalservice/service/MessageService.java
@@ -53,6 +53,7 @@ import static java.util.Optional.ofNullable;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.MediaType.TEXT_PLAIN_VALUE;
+import static se.sundsvall.postportalservice.Constants.CANCELLED;
 import static se.sundsvall.postportalservice.Constants.FAILED;
 import static se.sundsvall.postportalservice.Constants.PENDING;
 import static se.sundsvall.postportalservice.Constants.SIGNED;
@@ -210,8 +211,8 @@ public class MessageService {
 
 	/**
 	 * Cancels an ongoing e-signing case: withdraws it at the provider (via api-service-e-signing) and marks the local
-	 * case as {@code FAILED}. A case that has already completed ({@code SIGNED}) cannot be cancelled. The provider also
-	 * confirms the withdrawal asynchronously through the signing-event callback, which re-applies the same status.
+	 * case as {@code CANCELLED}. A case that has already completed ({@code SIGNED}) cannot be cancelled. The provider also
+	 * confirms the withdrawal asynchronously through the signing-event callback, which re-applies the terminal state.
 	 */
 	@Transactional
 	public void cancelESigning(final String municipalityId, final String messageId) {
@@ -223,7 +224,7 @@ public class MessageService {
 		}
 
 		esigningIntegration.cancelSigning(municipalityId, signing.getProviderCaseId());
-		signing.setStatus(FAILED);
+		signing.setStatus(CANCELLED);
 		signingRepository.save(signing);
 	}
 

--- a/src/main/java/se/sundsvall/postportalservice/service/MessageService.java
+++ b/src/main/java/se/sundsvall/postportalservice/service/MessageService.java
@@ -51,9 +51,12 @@ import se.sundsvall.postportalservice.service.mapper.EntityMapper;
 import static java.util.Collections.emptyList;
 import static java.util.Optional.ofNullable;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.MediaType.TEXT_PLAIN_VALUE;
 import static se.sundsvall.postportalservice.Constants.FAILED;
+import static se.sundsvall.postportalservice.Constants.FEL;
 import static se.sundsvall.postportalservice.Constants.PENDING;
+import static se.sundsvall.postportalservice.Constants.SIGNERAT;
 import static se.sundsvall.postportalservice.configuration.DeliveryExecutorConfiguration.DELIVERY_EXECUTOR;
 import static se.sundsvall.postportalservice.integration.db.converter.MessageType.DIGITAL_REGISTERED_LETTER;
 import static se.sundsvall.postportalservice.integration.db.converter.MessageType.E_SIGNING;
@@ -202,6 +205,25 @@ public class MessageService {
 		signingRepository.save(signing);
 
 		return message.getId();
+	}
+
+	/**
+	 * Cancels an ongoing e-signing case: withdraws it at the provider (via api-service-e-signing) and marks the local
+	 * case as {@code FEL}. A case that has already completed ({@code SIGNERAT}) cannot be cancelled. The provider also
+	 * confirms the withdrawal asynchronously through the signing-event callback, which re-applies the same status.
+	 */
+	@Transactional
+	public void cancelESigning(final String municipalityId, final String messageId) {
+		final var signing = signingRepository.findByMessageId(messageId)
+			.orElseThrow(() -> Problem.valueOf(NOT_FOUND, "No e-signing case found for message with id '%s'".formatted(messageId)));
+
+		if (SIGNERAT.equals(signing.getStatus())) {
+			throw Problem.valueOf(BAD_REQUEST, "Cannot cancel a signing that is already completed");
+		}
+
+		esigningIntegration.cancelSigning(municipalityId, signing.getProviderCaseId());
+		signing.setStatus(FEL);
+		signingRepository.save(signing);
 	}
 
 	public String processCsvLetterRequest(final String municipalityId, final LetterCsvRequest request, final MultipartFile csvFile, final List<MultipartFile> attachments) {

--- a/src/main/java/se/sundsvall/postportalservice/service/MessageService.java
+++ b/src/main/java/se/sundsvall/postportalservice/service/MessageService.java
@@ -51,9 +51,12 @@ import se.sundsvall.postportalservice.service.mapper.EntityMapper;
 import static java.util.Collections.emptyList;
 import static java.util.Optional.ofNullable;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.MediaType.TEXT_PLAIN_VALUE;
 import static se.sundsvall.postportalservice.Constants.FAILED;
+import static se.sundsvall.postportalservice.Constants.FEL;
 import static se.sundsvall.postportalservice.Constants.PENDING;
+import static se.sundsvall.postportalservice.Constants.SIGNERAT;
 import static se.sundsvall.postportalservice.configuration.DeliveryExecutorConfiguration.DELIVERY_EXECUTOR;
 import static se.sundsvall.postportalservice.integration.db.converter.MessageType.DIGITAL_REGISTERED_LETTER;
 import static se.sundsvall.postportalservice.integration.db.converter.MessageType.E_SIGNING;
@@ -207,6 +210,25 @@ public class MessageService {
 		signingRepository.save(signing);
 
 		return message.getId();
+	}
+
+	/**
+	 * Cancels an ongoing e-signing case: withdraws it at the provider (via api-service-e-signing) and marks the local
+	 * case as {@code FEL}. A case that has already completed ({@code SIGNERAT}) cannot be cancelled. The provider also
+	 * confirms the withdrawal asynchronously through the signing-event callback, which re-applies the same status.
+	 */
+	@Transactional
+	public void cancelESigning(final String municipalityId, final String messageId) {
+		final var signing = signingRepository.findByMessageId(messageId)
+			.orElseThrow(() -> Problem.valueOf(NOT_FOUND, "No e-signing case found for message with id '%s'".formatted(messageId)));
+
+		if (SIGNERAT.equals(signing.getStatus())) {
+			throw Problem.valueOf(BAD_REQUEST, "Cannot cancel a signing that is already completed");
+		}
+
+		esigningIntegration.cancelSigning(municipalityId, signing.getProviderCaseId());
+		signing.setStatus(FEL);
+		signingRepository.save(signing);
 	}
 
 	public String processCsvLetterRequest(final String municipalityId, final LetterCsvRequest request, final MultipartFile csvFile, final List<MultipartFile> attachments) {

--- a/src/test/java/se/sundsvall/postportalservice/api/MessageResourceFailureTest.java
+++ b/src/test/java/se/sundsvall/postportalservice/api/MessageResourceFailureTest.java
@@ -542,4 +542,26 @@ class MessageResourceFailureTest {
 		});
 	}
 
+	@Test
+	void cancelESigning_BadRequest() {
+		final var response = webTestClient.delete()
+			.uri("/{municipalityId}/messages/e-signing/{messageId}", INVALID_MUNICIPALITY_ID, "invalid")
+			.exchange()
+			.expectStatus().isBadRequest()
+			.expectBody(ConstraintViolationProblem.class)
+			.returnResult()
+			.getResponseBody();
+
+		assertThat(response.getTitle()).isEqualTo("Constraint Violation");
+		assertThat(response.getViolations()).hasSize(2).satisfiesExactlyInAnyOrder(
+			violation -> {
+				assertThat(violation.field()).isEqualTo("cancelESigning.municipalityId");
+				assertThat(violation.message()).isEqualTo("not a valid municipality ID");
+			},
+			violation -> {
+				assertThat(violation.field()).isEqualTo("cancelESigning.messageId");
+				assertThat(violation.message()).isEqualTo("not a valid UUID");
+			});
+	}
+
 }

--- a/src/test/java/se/sundsvall/postportalservice/api/MessageResourceTest.java
+++ b/src/test/java/se/sundsvall/postportalservice/api/MessageResourceTest.java
@@ -214,4 +214,16 @@ class MessageResourceTest {
 		verify(messageServiceMock).processCsvSmsRequest(eq(MUNICIPALITY_ID), any(SmsCsvRequest.class), any(MultipartFile.class));
 	}
 
+	@Test
+	void cancelESigning_NoContent() {
+		final var messageId = "9ce333ec-a473-438b-8406-a71e957dc107";
+
+		webTestClient.delete()
+			.uri("/{municipalityId}/messages/e-signing/{messageId}", MUNICIPALITY_ID, messageId)
+			.exchange()
+			.expectStatus().isNoContent();
+
+		verify(messageServiceMock).cancelESigning(MUNICIPALITY_ID, messageId);
+	}
+
 }

--- a/src/test/java/se/sundsvall/postportalservice/api/MessageResourceTest.java
+++ b/src/test/java/se/sundsvall/postportalservice/api/MessageResourceTest.java
@@ -207,4 +207,16 @@ class MessageResourceTest {
 		verify(messageServiceMock).processCsvSmsRequest(eq(MUNICIPALITY_ID), any(SmsCsvRequest.class), any(MultipartFile.class));
 	}
 
+	@Test
+	void cancelESigning_NoContent() {
+		final var messageId = "9ce333ec-a473-438b-8406-a71e957dc107";
+
+		webTestClient.delete()
+			.uri("/{municipalityId}/messages/e-signing/{messageId}", MUNICIPALITY_ID, messageId)
+			.exchange()
+			.expectStatus().isNoContent();
+
+		verify(messageServiceMock).cancelESigning(MUNICIPALITY_ID, messageId);
+	}
+
 }

--- a/src/test/java/se/sundsvall/postportalservice/integration/esigning/EsigningIntegrationTest.java
+++ b/src/test/java/se/sundsvall/postportalservice/integration/esigning/EsigningIntegrationTest.java
@@ -36,4 +36,14 @@ class EsigningIntegrationTest {
 		verify(clientMock).createSigning(MUNICIPALITY_ID, request);
 		verifyNoMoreInteractions(clientMock);
 	}
+
+	@Test
+	void cancelSigning() {
+		final var providerCaseId = "case-1";
+
+		esigningIntegration.cancelSigning(MUNICIPALITY_ID, providerCaseId);
+
+		verify(clientMock).cancelSigning(MUNICIPALITY_ID, providerCaseId);
+		verifyNoMoreInteractions(clientMock);
+	}
 }

--- a/src/test/java/se/sundsvall/postportalservice/service/MessageServiceTest.java
+++ b/src/test/java/se/sundsvall/postportalservice/service/MessageServiceTest.java
@@ -74,6 +74,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpStatus.BAD_GATEWAY;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static se.sundsvall.postportalservice.Constants.CANCELLED;
 import static se.sundsvall.postportalservice.Constants.FAILED;
 import static se.sundsvall.postportalservice.Constants.SENT;
 import static se.sundsvall.postportalservice.TestDataFactory.MUNICIPALITY_ID;
@@ -239,7 +240,7 @@ class MessageServiceTest {
 
 		messageService.cancelESigning(MUNICIPALITY_ID, messageId);
 
-		assertThat(signing.getStatus()).isEqualTo(FAILED);
+		assertThat(signing.getStatus()).isEqualTo(CANCELLED);
 		verify(signingRepositoryMock).findByMessageId(messageId);
 		verify(esigningIntegrationMock).cancelSigning(MUNICIPALITY_ID, "case-1");
 		verify(signingRepositoryMock).save(signing);

--- a/src/test/java/se/sundsvall/postportalservice/service/MessageServiceTest.java
+++ b/src/test/java/se/sundsvall/postportalservice/service/MessageServiceTest.java
@@ -72,6 +72,8 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpStatus.BAD_GATEWAY;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static se.sundsvall.postportalservice.Constants.FAILED;
 import static se.sundsvall.postportalservice.Constants.SENT;
 import static se.sundsvall.postportalservice.TestDataFactory.MUNICIPALITY_ID;
@@ -222,6 +224,47 @@ class MessageServiceTest {
 		assertThat(savedSigning.getProviderCaseId()).isEqualTo("case-1");
 		assertThat(savedSigning.getProvider()).isEqualTo("comfact");
 		assertThat(savedSigning.getStatus()).isEqualTo("INITIERAT");
+	}
+
+	@Test
+	void cancelESigning() {
+		final var messageId = "msg-1";
+		final var signing = SigningEntity.create().withProviderCaseId("case-1").withStatus("INVANTAR_SIGNERING");
+		when(signingRepositoryMock.findByMessageId(messageId)).thenReturn(Optional.of(signing));
+
+		messageService.cancelESigning(MUNICIPALITY_ID, messageId);
+
+		assertThat(signing.getStatus()).isEqualTo("FEL");
+		verify(signingRepositoryMock).findByMessageId(messageId);
+		verify(esigningIntegrationMock).cancelSigning(MUNICIPALITY_ID, "case-1");
+		verify(signingRepositoryMock).save(signing);
+	}
+
+	@Test
+	void cancelESigning_notFound() {
+		final var messageId = "msg-1";
+		when(signingRepositoryMock.findByMessageId(messageId)).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> messageService.cancelESigning(MUNICIPALITY_ID, messageId))
+			.isInstanceOf(Problem.class)
+			.hasFieldOrPropertyWithValue("status", NOT_FOUND)
+			.hasMessageContaining("No e-signing case found for message with id '%s'".formatted(messageId));
+
+		verify(signingRepositoryMock).findByMessageId(messageId);
+	}
+
+	@Test
+	void cancelESigning_alreadyCompleted() {
+		final var messageId = "msg-1";
+		final var signing = SigningEntity.create().withProviderCaseId("case-1").withStatus("SIGNERAT");
+		when(signingRepositoryMock.findByMessageId(messageId)).thenReturn(Optional.of(signing));
+
+		assertThatThrownBy(() -> messageService.cancelESigning(MUNICIPALITY_ID, messageId))
+			.isInstanceOf(Problem.class)
+			.hasFieldOrPropertyWithValue("status", BAD_REQUEST)
+			.hasMessageContaining("Cannot cancel a signing that is already completed");
+
+		verify(signingRepositoryMock).findByMessageId(messageId);
 	}
 
 	/**

--- a/src/test/java/se/sundsvall/postportalservice/service/MessageServiceTest.java
+++ b/src/test/java/se/sundsvall/postportalservice/service/MessageServiceTest.java
@@ -72,6 +72,8 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpStatus.BAD_GATEWAY;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static se.sundsvall.postportalservice.Constants.FAILED;
 import static se.sundsvall.postportalservice.Constants.SENT;
 import static se.sundsvall.postportalservice.TestDataFactory.MUNICIPALITY_ID;
@@ -227,6 +229,47 @@ class MessageServiceTest {
 		assertThat(savedSigning.getProviderCaseId()).isEqualTo("case-1");
 		assertThat(savedSigning.getProvider()).isEqualTo("comfact");
 		assertThat(savedSigning.getStatus()).isEqualTo("INITIERAT");
+	}
+
+	@Test
+	void cancelESigning() {
+		final var messageId = "msg-1";
+		final var signing = SigningEntity.create().withProviderCaseId("case-1").withStatus("INVANTAR_SIGNERING");
+		when(signingRepositoryMock.findByMessageId(messageId)).thenReturn(Optional.of(signing));
+
+		messageService.cancelESigning(MUNICIPALITY_ID, messageId);
+
+		assertThat(signing.getStatus()).isEqualTo("FEL");
+		verify(signingRepositoryMock).findByMessageId(messageId);
+		verify(esigningIntegrationMock).cancelSigning(MUNICIPALITY_ID, "case-1");
+		verify(signingRepositoryMock).save(signing);
+	}
+
+	@Test
+	void cancelESigning_notFound() {
+		final var messageId = "msg-1";
+		when(signingRepositoryMock.findByMessageId(messageId)).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> messageService.cancelESigning(MUNICIPALITY_ID, messageId))
+			.isInstanceOf(Problem.class)
+			.hasFieldOrPropertyWithValue("status", NOT_FOUND)
+			.hasMessageContaining("No e-signing case found for message with id '%s'".formatted(messageId));
+
+		verify(signingRepositoryMock).findByMessageId(messageId);
+	}
+
+	@Test
+	void cancelESigning_alreadyCompleted() {
+		final var messageId = "msg-1";
+		final var signing = SigningEntity.create().withProviderCaseId("case-1").withStatus("SIGNERAT");
+		when(signingRepositoryMock.findByMessageId(messageId)).thenReturn(Optional.of(signing));
+
+		assertThatThrownBy(() -> messageService.cancelESigning(MUNICIPALITY_ID, messageId))
+			.isInstanceOf(Problem.class)
+			.hasFieldOrPropertyWithValue("status", BAD_REQUEST)
+			.hasMessageContaining("Cannot cancel a signing that is already completed");
+
+		verify(signingRepositoryMock).findByMessageId(messageId);
 	}
 
 	/**


### PR DESCRIPTION
Adds `DELETE /{municipalityId}/messages/e-signing/{messageId}` to cancel an in-progress signing.

- `MessageService.cancelESigning` finds the case via `SigningRepository.findByMessageId(..)`, withdraws it at the provider through `EsigningIntegration`/`EsigningClient` (`DELETE .../e-signing/signings/{providerCaseId}`), and marks the local case `FEL`.
- A completed (`SIGNERAT`) case cannot be cancelled → 400. The Comfact `withdrawn` webhook later re-applies `FEL` via the consume flow (idempotent).
- New `Constants.FEL`. Full unit coverage (service happy/not-found/already-completed, resource happy + bad-request, integration passthrough); OpenAPI regenerated.

Requires the e-signing-side cancel passthrough (separate PR in api-service-e-signing). Stacked on #100 (`feature/esigning-consume`).