### PR TITLE
Bump version 1.8 → 1.9 (e-signing feature)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 	<groupId>se.sundsvall.postportalservice</groupId>
 	<artifactId>api-service-postportalservice</artifactId>
-	<version>1.8</version>
+	<version>1.9</version>
 	<name>api-service-postportalservice</name>
 	<properties>
 		<generated-sources-path>${project.build.directory}/generated-sources</generated-sources-path>

--- a/src/integration-test/resources/api/openapi.yaml
+++ b/src/integration-test/resources/api/openapi.yaml
@@ -5,7 +5,7 @@ info:
   license:
     name: MIT License
     url: https://opensource.org/licenses/MIT
-  version: "1.8"
+  version: "1.9"
 servers:
 - url: http://localhost:52228
   description: Generated server url


### PR DESCRIPTION
Steps the module minor version for the e-signing feature that merged to main (initiate #98, consume #100, signed-document #101, cancel #102, attachments) — the version was left at 1.8 (set by an unrelated dept44-parent bump). Two-line change: pom `<version>` + the checked-in openapi `info.version`.