### PR TITLE
Sync vendored e-signing client spec version 1.0 → 2.1

### DIFF
--- a/src/main/resources/integrations/esigning.yml
+++ b/src/main/resources/integrations/esigning.yml
@@ -5,7 +5,7 @@ info:
   license:
     name: MIT License
     url: https://opensource.org/licenses/MIT
-  version: "1.0"
+  version: "2.1"
 servers:
   - url: http://localhost:8080
     description: Generated server url


### PR DESCRIPTION
The vendored e-signing contract (`integrations/esigning.yml`) still declared `info.version: 1.0` while api-service-e-signing is now 2.1. Bumps the string to match the provider (metadata only — not used by client model generation; the endpoints/schemas were already synced with the attachments + cancel work). Keeps greve's stale-client report clean.